### PR TITLE
devxp: enable devcontainers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+FROM mcr.microsoft.com/devcontainers/javascript-node:20
+
+# Install Bun
+RUN npm install -g bun

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+{
+	"name": "Bun",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/common-utils:2": {
+			"installZsh": "true",
+			"username": "node",
+			"upgradePackages": "true"
+		},
+		"ghcr.io/devcontainers/features/node:1": {
+			"version": "none"
+		},
+		"ghcr.io/devcontainers/features/git:1": {
+      "version": "latest",
+      "ppa": "false"
+    }
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+        "oven.bun-vscode",
+        "editorconfig.editorconfig"
+			]
+		}
+	},
+	"remoteUser": "node"
+}


### PR DESCRIPTION
This Pull Request was initially planned to setup production containers but since front-end doesn't quite require one except for development, I've left this PR to enable dev containers only.

I'll enable a compose file before the release of `0.1.0` to ensure we have an easy way of deploying depending on the topology.